### PR TITLE
SC-2 (bug) [SonarQube] Remove the declaration of the unused 'task' variable.

### DIFF
--- a/test/taskService.test.js
+++ b/test/taskService.test.js
@@ -5,7 +5,7 @@ const { findTaskById } = require('../src/taskService');
 describe('findTaskById', () => {
   it('should return task with valid ID', () => {
     // Missing mock or actual asynchronous handling
-    let task = findTaskById(1, (err, task) => {
+    findTaskById(1, (err, task) => {
       if (err) {
         console.error(err);
       }
@@ -16,7 +16,7 @@ describe('findTaskById', () => {
   });
 
   it('should handle task not found', () => {
-    let task = findTaskById(999, (err, task) => {
+    findTaskById(999, (err, task) => {
       if (err) {
         console.log(err);  // Improper error handling
       }


### PR DESCRIPTION
SC-2 (bug) [SonarQube] Remove the declaration of the unused 'task' variable.